### PR TITLE
[Small Fix] README doc > dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Repository for a Docker image of the Pixelmon Minecraft mod
 Use ./run.sh to run or use below setup for docker-compose
 
 ```
+services:
   pixelmon:
     container_name: pixelmon
     image: walthowd/pixelmon


### PR DESCRIPTION
Added a missing ```services:``` in front of the dockerfile. 

Without "services:" in front docker will not accept the dockerfile because of syntax erros.  